### PR TITLE
Chart Release GH Action - Flatten source charts dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request: {}
 
 jobs:
   release:
@@ -23,17 +22,21 @@ jobs:
       - name: Flatten charts directory
         env:
           CHARTS: charts/consul charts/consul-backup-gcs/consul-backup-gcs charts/gcloud-cron/gcloud-cron charts/vault/incubator/vault charts/basisai/consul-esm charts/basisai/telegraf charts/fluent-bit/stable/fluent-bit charts/kube-janitor charts/bulldozer-deployment/bulldozer-bot charts/eks-container-insights/eks-container-insights charts/gcp-billing-slack-notify/gcp-billing-slack-notify charts/cert-manager-aio/cert-manager-aio charts/basisai/default-psp charts/basisai/cloudsql-proxy
-          CHARTS_DIR: ./flatten_charts
+          CHARTS_DIR: flatten_charts
         run: |
+          git checkout --detach
           mkdir $CHARTS_DIR
           cp -r $CHARTS $CHARTS_DIR
+          ls -al $CHARTS_DIR
+          git add .
+          git commit -m "flatten-charts"
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.2
         with:
           # chart-releaser version https://github.com/helm/chart-releaser/releases
           version: v1.0.0-beta.1
-          charts_dir: ./flatten_charts
+          charts_dir: flatten_charts
           charts_repo_url: https://charts.amoy.ai
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_requests: {}
+  pull_request: {}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request: {}
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,20 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Flatten charts directory
+        env:
+          CHARTS: charts/consul charts/consul-backup-gcs/consul-backup-gcs charts/gcloud-cron/gcloud-cron charts/vault/incubator/vault charts/basisai/consul-esm charts/basisai/telegraf charts/fluent-bit/stable/fluent-bit charts/kube-janitor charts/bulldozer-deployment/bulldozer-bot charts/eks-container-insights/eks-container-insights charts/gcp-billing-slack-notify/gcp-billing-slack-notify charts/cert-manager-aio/cert-manager-aio charts/basisai/default-psp charts/basisai/cloudsql-proxy
+          CHARTS_DIR: ./flatten_charts
+        run: |
+          mkdir $CHARTS_DIR
+          cp -r $CHARTS $CHARTS_DIR
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.2
         with:
           # chart-releaser version https://github.com/helm/chart-releaser/releases
           version: v1.0.0-beta.1
-          charts_dir: charts/consul charts/consul-backup-gcs/consul-backup-gcs charts/gcloud-cron/gcloud-cron charts/vault/incubator/vault charts/basisai/consul-esm charts/basisai/telegraf charts/fluent-bit/stable/fluent-bit charts/kube-janitor charts/bulldozer-deployment/bulldozer-bot charts/eks-container-insights/eks-container-insights charts/gcp-billing-slack-notify/gcp-billing-slack-notify charts/cert-manager-aio/cert-manager-aio charts/basisai/default-psp charts/basisai/cloudsql-proxy
+          charts_dir: ./flatten_charts
           charts_repo_url: https://charts.amoy.ai
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_requests: {}
 
 jobs:
   release:
@@ -24,7 +25,7 @@ jobs:
         with:
           # chart-releaser version https://github.com/helm/chart-releaser/releases
           version: v1.0.0-beta.1
-          charts_dir: ./charts
+          charts_dir: charts/consul charts/consul-backup-gcs/consul-backup-gcs charts/gcloud-cron/gcloud-cron charts/vault/incubator/vault charts/basisai/consul-esm charts/basisai/telegraf charts/fluent-bit/stable/fluent-bit charts/kube-janitor charts/bulldozer-deployment/bulldozer-bot charts/eks-container-insights/eks-container-insights charts/gcp-billing-slack-notify/gcp-billing-slack-notify charts/cert-manager-aio/cert-manager-aio charts/basisai/default-psp charts/basisai/cloudsql-proxy
           charts_repo_url: https://charts.amoy.ai
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+flatten_charts/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-flatten_charts/


### PR DESCRIPTION
Fix two problems:
- Charts are nested at different levels due to submodules. Therefore, I need to flatten it in a temporary directory
- The chart releaser GH action is only looks for git file changes in the chart directory. As the above is created temporarily, I need to create a temporary git commit too.